### PR TITLE
Fix multiple event calls when removing/re-adding same record key

### DIFF
--- a/src/NormalizedCollection/libs/AbstractRecord.js
+++ b/src/NormalizedCollection/libs/AbstractRecord.js
@@ -28,6 +28,7 @@ function AbstractRecord(fieldMap, name, url) {
   self._map = fieldMap;
   self._name = name;
   self._url = url;
+  self.lastMergedValue = util.undef; // starts undefined since first value may be null
   self._obs = new util.Observable(
     ['value', 'child_added', 'child_removed', 'child_moved', 'child_changed'],
     {
@@ -231,6 +232,14 @@ AbstractRecord.prototype = {
       id = null;
       ref = this.getRef();
       prev = null;
+      // this is necessary because data may change in one of the merged nodes which does
+      // not correspond to the data we are displaying, so we need to actually do the
+      // content merge and evaluate the final object to decide if changes exist
+      var currentValue = this.mergeData(snaps);
+      if( util.isEqual(currentValue, this.lastMergedValue) ) {
+        return;
+      }
+      this.lastMergedValue = currentValue;
     }
     else {
       if( util.isObject(id) ) {
@@ -239,8 +248,6 @@ AbstractRecord.prototype = {
       }
       ref = this.getRef().ref().child(id);
     }
-    //todo probably just have the record types pass in the final snapshot to _trigger
-    //todo instead of this coupled and crazy dance
     if( snaps instanceof NormalizedSnapshot ) {
       args = [event, snaps];
     }

--- a/src/NormalizedCollection/libs/AbstractRecord.js
+++ b/src/NormalizedCollection/libs/AbstractRecord.js
@@ -234,11 +234,9 @@ AbstractRecord.prototype = {
       prev = null;
       // this is necessary because data may change in one of the merged nodes which does
       // not correspond to the data we are displaying, so we need to actually do the
-      // content merge and evaluate the final object to decide if changes exist
+      // content merge and evaluate the final object to decide if value event should be triggered
       var currentValue = this.mergeData(snaps);
-      if( util.isEqual(currentValue, this.lastMergedValue) ) {
-        return;
-      }
+      if( util.isEqual(currentValue, this.lastMergedValue) ) { return; }
       this.lastMergedValue = currentValue;
     }
     else {

--- a/src/NormalizedCollection/libs/Record.js
+++ b/src/NormalizedCollection/libs/Record.js
@@ -243,7 +243,6 @@ function ValueEventManager(rec) {
   this.rec = rec;
   this.pm = rec.getPathManager();
   this.running = false;
-  this.lastMergedValue = util.undef; // starts undefined
   this._init();
 }
 
@@ -271,11 +270,7 @@ ValueEventManager.prototype = {
     util.log('Record.ValueEventManager.update: url=%s, loadCompleted=%s', snap.ref().toString(), this.loadCompleted);
     if( this.loadCompleted ) {
       var snaps = util.toArray(this.snaps);
-      var newValue = this.rec.mergeData(snaps);
-      if( !util.isEqual(newValue, this.lastMergedValue) ) {
-        this.lastMergedValue = newValue;
-        this.rec.handler('value')(snaps);
-      }
+      this.rec.handler('value')(snaps);
     }
   },
 

--- a/src/NormalizedCollection/libs/RecordSet.js
+++ b/src/NormalizedCollection/libs/RecordSet.js
@@ -74,13 +74,16 @@ util.inherits(RecordSet, AbstractRecord, {
    * @returns {Object}
    */
   mergeData: function(snaps, isExport) {
-    var self = this;
-    var out = {};
-    util.each(snaps, function(snap) {
-      if( snap.val() !== null && self.filters.test(snap.val(), snap.key(), snap.getPriority()) ) {
-        out[snap.key()] = isExport? snap.exportVal() : snap.val();
-      }
-    });
+    var self = this, out = null;
+    // if the master path is empty, there is no data to be merged
+    if( snaps.length && snaps[0].val() !== null ) {
+      out = {};
+      util.each(snaps, function(snap) {
+        if( snap.val() !== null && self.filters.test(snap.val(), snap.key(), snap.getPriority()) ) {
+          out[snap.key()] = isExport? snap.exportVal() : snap.val();
+        }
+      });
+    }
     return out;
   },
 

--- a/test/NormalizedCollection/AbstractRecord.spec.js
+++ b/test/NormalizedCollection/AbstractRecord.spec.js
@@ -12,9 +12,11 @@ describe('AbstractRecord', function() {
       this._super(hp.stubFieldMap());
       this.setRef(hp.stubNormRef());
     };
+    var i = 0;
     util.inherits(Rec, AbstractRecord, {
       _start: jasmine.createSpy('_start'),
-      _stop: jasmine.createSpy('_stop')
+      _stop: jasmine.createSpy('_stop'),
+      mergeData: jasmine.createSpy('mergeData').and.callFake(function() { return 'call'+(++i); })
     });
   });
 

--- a/test/NormalizedCollection/Record.spec.js
+++ b/test/NormalizedCollection/Record.spec.js
@@ -127,13 +127,34 @@ describe('Record', function() {
       expect(data.nest.p4val['.value']).toBe(false);
     });
 
-    it('should include .value if export == true and value has a priority', function() {
+    it('should include .value if export === true and node has a priority', function() {
       var rec = new Record(makeFieldMap(makePathMgr()));
       var snaps = createSnaps(defaultIdFn,
-        null, null, {$value: 0, $priority: 1}, null
+        true, //first snap cannot be null
+        null,
+        {$value: 0, $priority: 1},
+        null
       );
       var data = rec.mergeData(snaps, true);
       expect(data.p3val).toEqual({'.value': 0, '.priority': 1});
+    });
+
+    it('should return null value if master path is null, even when other paths have data', function() {
+      var rec = new Record(makeFieldMap(makePathMgr()));
+      var snaps = createSnaps(defaultIdFn,
+        null,
+        {f99: 'p2.f99val'},
+        '99',
+        {$value: false, $priority: 44}
+      );
+      var data = rec.mergeData(snaps, true);
+      expect(data).toEqual(null);
+    });
+
+    it('should be null if no snapshots provided', function() {
+      var rec = new Record(makeFieldMap(makePathMgr()));
+      var data = rec.mergeData([], true);
+      expect(data).toEqual(null);
     });
 
     it('should include correct val for dynamic fields');

--- a/test/NormalizedCollection/RecordSet.spec.js
+++ b/test/NormalizedCollection/RecordSet.spec.js
@@ -184,6 +184,22 @@ describe('RecordSet', function() {
       expect(data).toHaveKey('r1');
       expect(data).not.toHaveKey('r2');
     });
+
+    it('should return null if master path is null', function() {
+      var fm = makeFieldMap(makePathMgr());
+      var recs = new RecordSet(fm, new Filter());
+      var snaps = createSnaps(fm);
+      snaps[0] = hp.stubSnap(snaps[0].ref, null, null);
+      var data = recs.mergeData(snaps, true);
+      expect(data).toEqual(null);
+    });
+
+    it('should return null if no snapshots provided', function() {
+      var fm = makeFieldMap(makePathMgr());
+      var recs = new RecordSet(fm, new Filter());
+      var data = recs.mergeData([], true);
+      expect(data).toEqual(null);
+    });
   });
 
   describe('#forEachKey', function() {


### PR DESCRIPTION
This mostly fixes #36 so that `child_changed` and `value` events are not called redundantly. The core problem was that [the old unwatch() call did not reference the correctly bound function ref](https://github.com/firebase/firebase-util/compare/kato-child_changed?expand=1#diff-9a6aea2f62f66b0d43625eec94fdb0e8L217). 

A secondary, more subtle, issue was that changes to the records may trigger value events, although the data being displayed to the client (which is determined by the `select()` clause) may not actually changed. I added a check into the AbstractRecord's `_trigger()` event to ensure value events are only triggered at appropriate times.

There are still a couple of edge cases where child_changed events can be triggered multiple times, such as when I manually delete the merged paths one-by-one, and do not start with the master record (this will result in a child_changed event for each secondary path, followed by a final one with `null` when the master is removed. These are appropriate and we don't have a way to distinguish these from normal changes to the data (i.e. we can't tell the users' intent and we can't wait indefinitely to see if they other paths are deleted because this mucks with the timing of events and ordering).
