### PR TITLE
Pagination bug fix: Show single item per page when pageSize is 1

### DIFF
--- a/src/Paginate/libs/Offset.js
+++ b/src/Paginate/libs/Offset.js
@@ -170,9 +170,9 @@ Offset.prototype._monitorEmptyOffset = function() {
 
 Offset.prototype._listen = function() {
   this._unsubscribe();
-  if( this.curr > this.keys.length ) {
+  if( this.curr >= this.keys.length ) {
     this._grow(function(/*changed*/) {
-      if( this.keys.length > this.curr ) {
+      if( this.keys.length >= this.curr ) {
         this._subscribe();
       }
       else {


### PR DESCRIPTION
Pagination doesn't work as expected when the pageSize parameter is set as 1 (i.e. I want to show one item per page). I think this might be because of `this.curr > this.keys.length` condition in offset.js.
