### PR TITLE
Fixed: Errors not being passed to the callbacks

### DIFF
--- a/src/common/libs/queue.js
+++ b/src/common/libs/queue.js
@@ -66,7 +66,7 @@ Queue.prototype = {
 
   handler: function(fn, context) {
     this._runOrStore(function() {
-      fn.apply(context, this.hasErrors()? this.getErrors() : null);
+      fn.apply(context, [this.hasErrors()? this.getErrors() : null]);
     });
     return this;
   },


### PR DESCRIPTION
Hi, I was having problems with AngularFire and just saw the issue #56.

Then I debugged and found the little bug that was causing the problem, as you can see the callbacks were not receiving the error parameter but always undefined.
