### PR TITLE
Replace built files with source in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
     "realtime",
     "utilities"
   ],
-  "main": "dist/firebase-util.min.js",
+  "main": "src/fbutil.js",
   "files": [
-    "dist/**",
+    "src/**",
     "LICENSE",
     "README.md",
     "package.json"


### PR DESCRIPTION
I ran into the same issue described in https://github.com/firebase/firebase-util/issues/57, which seems to stem from NPM using the built files in `dist` rather than the raw files in `src`.

I'm using Webpack to compile my CommonJS assets, and it throws the following error when including the built file in `dist`:

`This seems to be a pre-built javascript file. Though this is possible, it's not recommended. Try to require the original source to get better results.`

A minor update in package.json seems to point it in the right direction.
