### PR TITLE
Change queue.handler to send null if the queue has no errors

### DIFF
--- a/src/common/libs/queue.js
+++ b/src/common/libs/queue.js
@@ -66,7 +66,7 @@ Queue.prototype = {
 
   handler: function(fn, context) {
     this._runOrStore(function() {
-      fn.apply(context, this.getErrors());
+      fn.apply(context, this.hasErrors()? this.getErrors() : [null]);
     });
     return this;
   },

--- a/test/NormalizedCollection/Record.spec.js
+++ b/test/NormalizedCollection/Record.spec.js
@@ -432,7 +432,7 @@ describe('Record', function() {
           expect(spy).not.toHaveBeenCalled();
         }
       });
-      expect(spy).toHaveBeenCalledWith();
+      expect(spy).toHaveBeenCalledWith(null);
     });
 
     it('triggers callback with correct context', function() {
@@ -450,7 +450,7 @@ describe('Record', function() {
       _.each(refs, function(ref) {
         try { ref.flush(); } catch(e) {}
       });
-      expect(spy).toHaveBeenCalledWith();
+      expect(spy).toHaveBeenCalledWith(null);
     });
 
     it('returns an error if any path returns an error', function() {

--- a/test/common/queue.spec.js
+++ b/test/common/queue.spec.js
@@ -1,0 +1,41 @@
+'use strict';
+var fbutil = require('../../src/common');
+
+describe('common/Queue.js', function() {
+
+   describe('#handler', function() {
+      it('should call handler callback with null if the queue has no errors', function() {
+         var q = fbutil.queue();
+         var handler = q.getHandler();
+
+         var callback =  jasmine.createSpy();
+
+         q.handler(callback);
+
+         expect(q.hasErrors()).toBe(0);
+
+         handler();
+
+         expect(q.hasErrors()).toBe(0);
+         expect(callback).toHaveBeenCalledWith(null);
+      });
+
+      it('should call handler callback with the first error if the queue has errors', function() {
+         var q = fbutil.queue();
+         var handler = q.getHandler();
+
+         var callback =  jasmine.createSpy();
+         var error = new Error();
+
+         q.handler(callback);
+
+         expect(q.hasErrors()).toBe(0);
+
+         handler(error);
+
+         expect(q.hasErrors()).toBe(1);
+         expect(callback).toHaveBeenCalledWith(error);
+      });
+   });
+
+});


### PR DESCRIPTION
This will make Firebase Util compatible with AngularFire, if queue.handler sends `undefined` instead of `null` AngularFire won't trigger the callbacks.

I tried my best with the tests, and I had to change two tests in `test/NormalizedCollection/Record.spec.js`.
